### PR TITLE
Update README to reflect BentoML joining Modular

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -34,7 +34,7 @@ For end-to-end performance and portability across the AI execution stack—hardw
 
 ### [🔥 Mojo](https://www.modular.com/blog/the-path-to-mojo-1-0): A faster future for AI inference
 
-Mojo is on the path to a stable 1.0 release in 2026, delivering semantic versioning and a proven high-performance model for CPU and GPU programming. As Mojo matures, BentoML will leverage its native hardware acceleration to push model inference performance even further.
+Mojo is on the path to a stable 1.0 release in 2026, delivering semantic versioning and a proven high-performance model for CPU and GPU programming. As Mojo matures, BentoML will leverage its native hardware acceleration to push model inference performance even further. See the [Mojo Roadmap](https://docs.modular.com/mojo/roadmap/) for more information.
 
 
 ## Get in touch 💬

--- a/profile/README.md
+++ b/profile/README.md
@@ -30,7 +30,7 @@ BentoCloud is the easist way to build and deploy with BentoML, in our cloud or y
 
 ### [⚡ Modular MAX](https://github.com/modular/modular): Hardware-optimized inference across any accelerator
 
-For end-to-end performance and portability across the AI execution stack—hardware-level optimization included—see [Modular MAX](https://www.modular.com/max).
+For end-to-end performance and portability across the AI execution stack, including hardware-level optimization, see [Modular MAX](https://www.modular.com/max).
 
 ### [🔥 Mojo](https://www.modular.com/blog/the-path-to-mojo-1-0): A faster future for AI inference
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -10,16 +10,6 @@
 <a href="http://bentoml.com">Website</a> | <a href="https://docs.bentoml.com">Docs</a> | <a href="https://bentoml.com/blog">Blog</a> | <a href="https://twitter.com/bentomlai">Twitter</a> | <a href="https://l.bentoml.com/join-slack">Community</a> | <a href="https://forum.modular.com/c/bento/31">Forum</a>
 </div>
 
-```mermaid
-flowchart TD
-    A["🚀 Your App / API"]
-    B["🍱 BentoML — Serving · Orchestration · Batching · Multi-model Chains"]
-    C["⚡ Modular MAX — Hardware-optimized Runtimes on Any Accelerator"]
-    D["🔥 Mojo — High-performance Kernel & Systems Programming"]
-    E["🖥️ Any Hardware · NVIDIA · AMD · CPU"]
-    A --> B --> C --> D --> E
-```
-
 ## What's cooking? 👩‍🍳
 
 ### [🍱 BentoML](https://github.com/bentoml/BentoML): The Unified Serving Framework for AI/ML Systems
@@ -46,6 +36,15 @@ For end-to-end performance and portability across the AI execution stack—hardw
 
 Mojo is on the path to a stable 1.0 release in 2026, delivering semantic versioning and a proven high-performance model for CPU and GPU programming. As Mojo matures, BentoML will leverage its native hardware acceleration to push model inference performance even further. See the [Mojo Roadmap](https://docs.modular.com/mojo/roadmap/) for more information.
 
+```mermaid
+flowchart TD
+    A["🚀 Your App / API"]
+    B["🍱 BentoML — Serving · Orchestration · Batching · Multi-model Chains"]
+    C["⚡ Modular MAX — Hardware-optimized Runtimes on Any Accelerator"]
+    D["🔥 Mojo — High-performance Kernel & Systems Programming"]
+    E["🖥️ Any Hardware · NVIDIA · AMD · CPU"]
+    A --> B --> C --> D --> E
+```
 
 ## Get in touch 💬
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -31,6 +31,8 @@ BentoCloud is the easist way to build and deploy with BentoML, in our cloud or y
 
 👉 [Join our Slack community!](https://l.bentoml.com/join-slack)
 
+💬 Join the [Modular Discord](https://discord.gg/modular) and [Modular Forum](https://forum.modular.com/)
+
 👀 Follow us on X [@bentomlai](https://twitter.com/bentomlai) and [LinkedIn](https://www.linkedin.com/company/bentoml/)
 
 📖 Read our [blog](https://www.bentoml.com/blog)

--- a/profile/README.md
+++ b/profile/README.md
@@ -10,6 +10,16 @@
 <a href="http://bentoml.com">Website</a> | <a href="https://docs.bentoml.com">Docs</a> | <a href="https://bentoml.com/blog">Blog</a> | <a href="https://twitter.com/bentomlai">Twitter</a> | <a href="https://l.bentoml.com/join-slack">Community</a> | <a href="https://forum.modular.com/c/bento/31">Forum</a>
 </div>
 
+```mermaid
+flowchart TD
+    A["🚀 Your App / API"]
+    B["🍱 BentoML — Serving · Orchestration · Batching · Multi-model Chains"]
+    C["⚡ Modular MAX — Hardware-optimized Runtimes on Any Accelerator"]
+    D["🔥 Mojo — High-performance Kernel & Systems Programming"]
+    E["🖥️ Any Hardware · NVIDIA · AMD · CPU"]
+    A --> B --> C --> D --> E
+```
+
 ## What's cooking? 👩‍🍳
 
 ### [🍱 BentoML](https://github.com/bentoml/BentoML): The Unified Serving Framework for AI/ML Systems

--- a/profile/README.md
+++ b/profile/README.md
@@ -33,7 +33,7 @@ BentoCloud is the easist way to build and deploy with BentoML, in our cloud or y
 
 👉 [Join our Slack community!](https://l.bentoml.com/join-slack)
 
-💬 Join the [Modular Discord](https://discord.gg/modular) and [Modular Forum](https://forum.modular.com/)
+💬 Join the [Modular Discord](https://discord.gg/modular) and [Modular Forum](https://forum.modular.com/c/bento/31)
 
 👀 Follow us on X [@bentomlai](https://twitter.com/bentomlai) and [LinkedIn](https://www.linkedin.com/company/bentoml/)
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -30,7 +30,7 @@ BentoCloud is the easist way to build and deploy with BentoML, in our cloud or y
 
 ### [⚡ Modular MAX](https://github.com/modular/modular): Hardware-optimized inference across any accelerator
 
-For end-to-end performance and portability across the AI execution stack—hardware-level optimization included—see Modular MAX.
+For end-to-end performance and portability across the AI execution stack—hardware-level optimization included—see [Modular MAX](https://www.modular.com/max).
 
 ### [🔥 Mojo](https://www.modular.com/blog/the-path-to-mojo-1-0): A faster future for AI inference
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -28,6 +28,14 @@ Run any open-source LLMs (Llama, Mistral, Qwen, Phi and more) or custom fine-tun
 
 BentoCloud is the easist way to build and deploy with BentoML, in our cloud or yours. It brings fast and scalable inference infrastructure into any cloud, allowing AI teams to move 10x faster in building AI applications with ML/AI models, while reducing compute cost - by maxmizing compute utilization, fast GPU autoscaling, minimimal coldstarts and full observability. [Sign up today!](https://www.bentoml.com/).
 
+### [⚡ Modular MAX](https://github.com/modular/modular): Hardware-optimized inference across any accelerator
+
+For end-to-end performance and portability across the AI execution stack—hardware-level optimization included—see Modular MAX.
+
+### [🔥 Mojo](https://www.modular.com/blog/the-path-to-mojo-1-0): A faster future for AI inference
+
+Mojo is on the path to a stable 1.0 release in 2026, delivering semantic versioning and a proven high-performance model for CPU and GPU programming. As Mojo matures, BentoML will leverage its native hardware acceleration to push model inference performance even further.
+
 
 ## Get in touch 💬
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -7,7 +7,7 @@
 
 
 <div align="center">
-<a href="http://bentoml.com">Website</a> | <a href="https://docs.bentoml.com">Docs</a> | <a href="https://bentoml.com/blog">Blog</a> | <a href="https://twitter.com/bentomlai">Twitter</a> | <a href="https://l.bentoml.com/join-slack">Community</a>
+<a href="http://bentoml.com">Website</a> | <a href="https://docs.bentoml.com">Docs</a> | <a href="https://bentoml.com/blog">Blog</a> | <a href="https://twitter.com/bentomlai">Twitter</a> | <a href="https://l.bentoml.com/join-slack">Community</a> | <a href="https://forum.modular.com/c/bento/31">Forum</a>
 </div>
 
 ## What's cooking? 👩‍🍳
@@ -33,7 +33,7 @@ BentoCloud is the easist way to build and deploy with BentoML, in our cloud or y
 
 👉 [Join our Slack community!](https://l.bentoml.com/join-slack)
 
-💬 Join the [Modular Discord](https://discord.gg/modular) and [Modular Forum](https://forum.modular.com/c/bento/31)
+💬 Join the [Modular Discord](https://discord.gg/modular) and [Modular Forum](https://forum.modular.com/)
 
 👀 Follow us on X [@bentomlai](https://twitter.com/bentomlai) and [LinkedIn](https://www.linkedin.com/company/bentoml/)
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -7,7 +7,7 @@
 
 
 <div align="center">
-<a href="http://bentoml.com">Website</a> | <a href="https://docs.bentoml.com">Docs</a> | <a href="https://bentoml.com/blog">Blog</a> | <a href="https://twitter.com/bentomlai">Twitter</a> | <a href="https://l.bentoml.com/join-slack">Community</a> | <a href="https://forum.modular.com/c/bento/31">Forum</a>
+<a href="http://bentoml.com">Website</a> | <a href="https://docs.bentoml.com">Docs</a> | <a href="https://bentoml.com/blog">Blog</a> | <a href="https://twitter.com/bentomlai">Twitter</a> | <a href="https://discord.gg/modular">Community</a> | <a href="https://forum.modular.com/c/bento/31">Forum</a>
 </div>
 
 ## What's cooking? 👩‍🍳
@@ -30,11 +30,11 @@ BentoCloud is the easist way to build and deploy with BentoML, in our cloud or y
 
 ### [⚡ Modular MAX](https://github.com/modular/modular): Hardware-optimized inference across any accelerator
 
-For end-to-end performance and portability across the AI execution stack, including hardware-level optimization, see [Modular MAX](https://www.modular.com/max).
+For end-to-end performance and portability across the AI execution stack, see [Modular MAX](https://www.modular.com/max).
 
 ### [🔥 Mojo](https://www.modular.com/blog/the-path-to-mojo-1-0): A faster future for AI inference
 
-Mojo is on the path to a stable 1.0 release in 2026, delivering semantic versioning and a proven high-performance model for CPU and GPU programming. As Mojo matures, BentoML will leverage its native hardware acceleration to push model inference performance even further. See the [Mojo Roadmap](https://docs.modular.com/mojo/roadmap/) for more information.
+Mojo is on the path to a stable 1.0 release in 2026, delivering semantic versioning and a high-performance language for CPU and GPU programming. As Mojo matures, BentoML will leverage Mojo's compiled performance for CPU and GPU kernels to push model inference performance even further. See the [Mojo Roadmap](https://docs.modular.com/mojo/roadmap/) for more information.
 
 ```mermaid
 flowchart TD
@@ -47,8 +47,6 @@ flowchart TD
 ```
 
 ## Get in touch 💬
-
-👉 [Join our Slack community!](https://l.bentoml.com/join-slack)
 
 💬 Join the [Modular Discord](https://discord.gg/modular) and [Modular Forum](https://forum.modular.com/)
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,5 +1,7 @@
 # Welcome to BentoML 👋  [![Twitter Follow](https://img.shields.io/twitter/follow/bentomlai?style=social)](https://twitter.com/bentomlai) [![Slack](https://img.shields.io/badge/Slack-Join-4A154B?style=social)](https://l.bentoml.com/join-slack)
 
+> [!IMPORTANT]
+> BentoML is now part of [Modular](https://github.com/modular/modular). Together, we're building a unified stack for high-performance AI inference.
 
 [![github banner](https://github.com/user-attachments/assets/a5719b64-615b-4f73-8342-b844e380bdd5)](http://bentoml.com)
 


### PR DESCRIPTION
## Summary

Since Modular acquired BentoML, this PR updates the BentoML org README to reflect the new relationship with Modular and surface relevant Modular resources to the BentoML community.

**1. Acquisition banner**

Adds a prominent `[!IMPORTANT]` callout directly below the title announcing that BentoML is now part of [Modular](https://github.com/modular/modular).

**2. Community link in top nav → Modular Discord**

Replaces the existing `Community` link (previously Slack) with the Modular Discord. Also adds a `Forum` link pointing to the BentoML-specific Modular Forum category: https://forum.modular.com/c/bento/31

**3. Modular MAX entry in What's cooking**

Adds a new section highlighting [Modular MAX](https://www.modular.com/max) for end-to-end performance and portability across the AI execution stack.

**4. Mojo 1.0 entry in What's cooking**

Adds a new section on [Mojo's path to 1.0](https://www.modular.com/blog/the-path-to-mojo-1-0) in 2026 and what it means for BentoML inference performance, with a link to the [Mojo Roadmap](https://docs.modular.com/mojo/roadmap/) for more information.

**5. Unified stack diagram**

Adds a Mermaid flowchart at the bottom of the What's cooking section showing how the full stack layers together — BentoML → MAX → Mojo → Any Hardware — giving developers an immediate mental model of what the acquisition means in practice.

**6. Modular community links in Get in touch**

Replaces the Slack community CTA with Modular's community channels:

- 💬 [Modular Discord](https://discord.gg/modular)
- 💬 [Modular Forum](https://forum.modular.com/)